### PR TITLE
Fix FC when launching specific apps which require exact package/action to be assigned

### DIFF
--- a/app/src/main/java/cn/modificator/launcher/widgets/EInkLauncherView.java
+++ b/app/src/main/java/cn/modificator/launcher/widgets/EInkLauncherView.java
@@ -325,7 +325,9 @@ public class EInkLauncherView extends ViewGroup {
       Intent intent = new Intent();
       intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
       intent.addCategory(Intent.CATEGORY_LAUNCHER);
+      intent.setAction(Intent.ACTION_MAIN);
       intent.setComponent(componentName);
+      intent.setPackage(info.activityInfo.packageName);
       v.getContext().startActivity(intent);
 
     }


### PR DESCRIPTION
Dear Modificator,

This request is for trying to avoid force close when launching specific apps, which require exact package/action to be assigned.

For example, `KyoboEbookLibrary` app (Electronic library app in South Korea) and other apps from company `Kyobo` cannot be launched with E-Ink Launcher if `package` and `action` are not assigned in an intent.

 * KyoboEbookLibrary app [GooglePlay](https://play.google.com/store/apps/details?id=com.kyobo.ebook.b2b.phone.type3), [APKPure](https://apkpure.com/%EA%B5%90%EB%B3%B4%EB%AC%B8%EA%B3%A0-%EC%A0%84%EC%9E%90%EB%8F%84%EC%84%9C%EA%B4%80/com.kyobo.ebook.b2b.phone.type3)

Although this proposal was not broadly tested..., but Android API to find intent for app (`ApplicationPackageManager.getLaunchIntentForPackage()`) seems that it also does the similar job (see [code](https://android.googlesource.com/platform/frameworks/base/+/742a67127366c376fdf188ff99ba30b27d3bf90c/core/java/android/app/ApplicationPackageManager.java#100)).

Please consider this request.

Thank you.